### PR TITLE
Implement Audit-Trail & Verify and Rebuilding Data Structure 

### DIFF
--- a/lib/merkle_tree_elixir.ex
+++ b/lib/merkle_tree_elixir.ex
@@ -1,7 +1,6 @@
 defmodule MerkleTreeElixir do
-  
-  defstruct depth: 0, root_hash: nil, left_child: nil, right_child: nil, leafs: [nil] 
-  
+  defstruct depth: 0, root_hash: nil, left_child: nil, right_child: nil, leafs: [nil]
+
   def new_tree(), do: %MerkleTreeElixir{}
 
   def add_leaf_to_tree(data, nil), do: {0, hash_data(data), nil, nil}
@@ -21,14 +20,23 @@ defmodule MerkleTreeElixir do
     {1, hash_data(data, new_data), left, {0, hash_data(new_data), nil, nil}}
   end
 
-  def append_leaf_to_unbalanced_tree(new_data, {depth, _, {d, data, left_left, right_right}, right}) do
+  def append_leaf_to_unbalanced_tree(
+        new_data,
+        {depth, _, {d, data, left_left, right_right}, right}
+      ) do
     foo = append_leaf_to_unbalanced_tree(new_data, right)
     {depth, value, _, _} = foo
     {depth + 1, hash_data(data, value), {d, data, left_left, right_right}, foo}
   end
 
   def append_leaf_to_balanced_tree(data, tree = %MerkleTreeElixir{}) do
-    %MerkleTreeElixir{depth: tree.depth + 1, root_hash: hash_data(tree.root_hash, data), left_child: {tree.depth, tree.root_hash, tree.left_child, tree.right_child}, right_child: bubble_down(tree.depth, data), leafs: tree.leafs ++ [{hash_data(data), :left}]}
+    %MerkleTreeElixir{
+      depth: tree.depth + 1,
+      root_hash: hash_data(tree.root_hash, data),
+      left_child: {tree.depth, tree.root_hash, tree.left_child, tree.right_child},
+      right_child: bubble_down(tree.depth, data),
+      leafs: tree.leafs ++ [{hash_data(data), :left}]
+    }
   end
 
   def bubble_down(0, data) do

--- a/lib/merkle_tree_elixir.ex
+++ b/lib/merkle_tree_elixir.ex
@@ -1,51 +1,51 @@
 defmodule MerkleTreeElixir do
-  def tree(), do: nil
+  def new_tree(), do: nil
 
-  def insert(data, nil), do: {0, hash(data), nil, nil}
+  def insert_leaf_into_tree(data, nil), do: {0, hash_data(data), nil, nil}
 
-  def insert(data, tree) do
-    case is_balanced(tree) do
-      true -> add_parent(data, tree)
-      false -> append_to_rightmost(data, tree)
+  def insert_leaf_into_tree(data, tree) do
+    case is_balanced_tree(tree) do
+      true -> append_leaf_to_balanced_tree(data, tree)
+      false -> append_leaf_to_unbalanced_tree(data, tree)
     end
   end
 
-  def is_balanced({_, _, nil, nil}), do: true
-  def is_balanced({_, _, left, nil}), do: false
-  def is_balanced({_, _, left, right}), do: is_balanced(right)
+  def is_balanced_tree({_, _, nil, nil}), do: true
+  def is_balanced_tree({_, _, left, nil}), do: false
+  def is_balanced_tree({_, _, left, right}), do: is_balanced_tree(right)
 
-  def append_to_rightmost(new_data, {depth, data, left, nil}) do
-    {1, hash(data, new_data), left, {0, hash(new_data), nil, nil}}
+  def append_leaf_to_unbalanced_tree(new_data, {depth, data, left, nil}) do
+    {1, hash_data(data, new_data), left, {0, hash_data(new_data), nil, nil}}
   end
 
-  def append_to_rightmost(new_data, {depth, _, {d, data, left_left, right_right}, right}) do
-    foo = append_to_rightmost(new_data, right)
+  def append_leaf_to_unbalanced_tree(new_data, {depth, _, {d, data, left_left, right_right}, right}) do
+    foo = append_leaf_to_unbalanced_tree(new_data, right)
     {depth, value, _, _} = foo
-    {depth + 1, hash(data, value), {d, data, left_left, right_right}, foo}
+    {depth + 1, hash_data(data, value), {d, data, left_left, right_right}, foo}
   end
 
-  def add_parent(data, {depth, value, left, right}) do
-    {depth + 1, hash(value, data), {depth, value, left, right}, bubble_down(depth, data)}
+  def append_leaf_to_balanced_tree(data, {depth, value, left, right}) do
+    {depth + 1, hash_data(value, data), {depth, value, left, right}, bubble_down(depth, data)}
   end
 
   def bubble_down(0, data) do
-    {0, hash(data), nil, nil}
+    {0, hash_data(data), nil, nil}
   end
 
   def bubble_down(depth, data) do
-    {depth, hash(data), bubble_down(depth - 1, data), nil}
+    {depth, hash_data(data), bubble_down(depth - 1, data), nil}
   end
 
-  defp hash(data) do
+  defp hash_data(data) do
     to_string(data)
-    # :crypto.hash(:sha256, to_string(data)) 
+    # :crypto.hash_data(:sha256, to_string(data)) 
     # |> Base.encode16 
     # |> String.downcase
   end
 
-  defp hash(one, two) do
+  defp hash_data(one, two) do
     to_string(one <> two)
-    # :crypto.hash(:sha256, to_string(data)) 
+    # :crypto.hash_data(:sha256, to_string(data)) 
     # |> Base.encode16 
     # |> String.downcase
   end

--- a/lib/merkle_tree_elixir.ex
+++ b/lib/merkle_tree_elixir.ex
@@ -5,17 +5,34 @@ defmodule MerkleTreeElixir do
 
   def add_leaf_to_tree(data, nil), do: {0, hash_data(data), nil, nil}
 
-  # def add_leaf_to_tree(data, tree) do
-  #   case is_balanced_tree(tree) do
-  #     true -> append_leaf_to_balanced_tree(data, tree)
-  #     false -> append_leaf_to_unbalanced_tree(data, tree)
-  #   end
-  # end
+  def add_leaf_to_tree(data, tree) do
+    case is_balanced_tree(tree) do
+      true -> append_leaf_to_balanced_tree(data, tree)
+      false -> append_leaf_to_unbalanced_tree(data, tree)
+    end
+  end
+
+  def audit_trail(hash_to_be_audited, tree = %MerkleTreeElixir{}) do
+    index = find_index_of_leaf(0, hash_to_be_audited, tree.leafs)
+    case index do
+      false -> false
+      _ -> audit_trail(index, )
+    end
+  end
+
+  def audit_trail(index, tree = %MerkleTreeElixir{}) do
+    case (index < (:math.pow(2, tree.depth)/2)) do
+      
+    end
+  end
+
+  def find_index_of_leaf(_, _, []), do: false
+  def find_index_of_leaf(index, hash, [{hash, _}|_]), do: index
+  def find_index_of_leaf(index, hash, [H|T]), do: find_index_of_leaf(index+1, hash, T)
 
   def is_balanced_tree({_, _, nil, nil}), do: true
   def is_balanced_tree({_, _, _, nil}), do: false
   def is_balanced_tree({_, _, _, right}), do: is_balanced_tree(right)
-
   def is_balanced_tree(
         %MerkleTreeElixir{
           depth: 0,
@@ -26,7 +43,6 @@ defmodule MerkleTreeElixir do
         }
       ),
       do: true
-
   def is_balanced_tree(tree = %MerkleTreeElixir{}), do: is_balanced_tree(tree.right_child)
 
   def append_leaf_to_unbalanced_tree(new_data, {_, data, left, nil}) do
@@ -70,14 +86,14 @@ defmodule MerkleTreeElixir do
     {depth, hash_data(data), bubble_down(depth - 1, data), nil}
   end
 
-  defp hash_data(data) do
+  def hash_data(data) do
     to_string(data)
     # :crypto.hash_data(:sha256, to_string(data)) 
     # |> Base.encode16 
     # |> String.downcase
   end
 
-  defp hash_data(one, two) do
+  def hash_data(one, two) do
     to_string(one <> two)
     # :crypto.hash_data(:sha256, to_string(data)) 
     # |> Base.encode16 

--- a/lib/merkle_tree_elixir.ex
+++ b/lib/merkle_tree_elixir.ex
@@ -27,8 +27,8 @@ defmodule MerkleTreeElixir do
     {depth + 1, hash_data(data, value), {d, data, left_left, right_right}, foo}
   end
 
-  def append_leaf_to_balanced_tree(data, {depth, value, left, right}) do
-    {depth + 1, hash_data(value, data), {depth, value, left, right}, bubble_down(depth, data)}
+  def append_leaf_to_balanced_tree(data, tree = %MerkleTreeElixir{}) do
+    %MerkleTreeElixir{depth: tree.depth + 1, root_hash: hash_data(tree.root_hash, data), left_child: {tree.depth, tree.root_hash, tree.left_child, tree.right_child}, right_child: bubble_down(tree.depth, data), leafs: tree.leafs ++ [{hash_data(data), :left}]}
   end
 
   def bubble_down(0, data) do

--- a/lib/merkle_tree_elixir.ex
+++ b/lib/merkle_tree_elixir.ex
@@ -35,32 +35,52 @@ defmodule MerkleTreeElixir do
     end
   end
 
-  def audit_trail(_, {_, _, nil, nil}, list), do: list
+  def audit_trail(index, {_, hash, nil, nil}, list) do
+    case rem(index, 2) do
+      0 -> list ++ [{hash, :left}]
+      1 -> list ++ [{hash, :right}]
+    end
+  end
 
-  def audit_trail(index, {depth, hash, left_child, nil}, list),
+  def audit_trail(index, {_, _, left_child, nil}, list),
     do: audit_trail(index, left_child, list ++ [{nil, :right}])
 
   def audit_trail(
         index,
-        {depth, hash, {left_depth, left_hash, left_left, left_right},
+        {depth, _, {left_depth, left_hash, left_left, left_right},
          {right_depth, right_hash, right_left, right_right}},
         list
       ) do
-    case index < :math.pow(2, depth) / 2 do
+    case part_of_left_subtree?(depth, index) do
       true ->
         audit_trail(
           index,
-          {right_depth, right_hash, right_left, right_right},
+          {left_depth, left_hash, left_left, left_right},
           list ++ [{right_hash, :right}]
         )
 
       false ->
         audit_trail(
           index,
-          {left_depth, left_hash, left_left, left_right},
+          {right_depth, right_hash, right_left, right_right},
           list ++ [{left_hash, :left}]
         )
     end
+  end
+
+  def verify_audit_trail(_, []), do: false
+  def verify_audit_trail(root_hash, list), do: verify_audit_trail(root_hash, "", Enum.reverse(list))
+  def verify_audit_trail(root_hash, root_hash, []), do: true
+  def verify_audit_trail(root_hash, _, []), do: false
+
+  def verify_audit_trail(root_hash, audit_hash, [{nil, :right} | tail]) do
+    verify_audit_trail(root_hash, hash_data(audit_hash, ""),tail)
+  end
+  def verify_audit_trail(root_hash, audit_hash, [{new_hash, :right} | tail]) do
+    verify_audit_trail(root_hash, hash_data(audit_hash, new_hash),tail)
+  end
+  def verify_audit_trail(root_hash, audit_hash, [{new_hash, :left} | tail]) do
+    verify_audit_trail(root_hash, hash_data(new_hash, audit_hash), tail)
   end
 
   def is_balanced_tree({_, _, nil, nil}), do: true
@@ -124,6 +144,10 @@ defmodule MerkleTreeElixir do
     # :crypto.hash_data(:sha256, to_string(data)) 
     # |> Base.encode16 
     # |> String.downcase
+  end
+
+  def part_of_left_subtree?(depth, index) do
+    index < (:math.pow(2, depth) / 2)
   end
 
   def hash_data(one, two) do

--- a/lib/merkle_tree_elixir.ex
+++ b/lib/merkle_tree_elixir.ex
@@ -1,9 +1,12 @@
 defmodule MerkleTreeElixir do
-  def new_tree(), do: nil
+  
+  defstruct depth: 0, root_hash: nil, left_child: nil, right_child: nil, leafs: [nil] 
+  
+  def new_tree(), do: %MerkleTreeElixir{}
 
-  def insert_leaf_into_tree(data, nil), do: {0, hash_data(data), nil, nil}
+  def add_leaf_to_tree(data, nil), do: {0, hash_data(data), nil, nil}
 
-  def insert_leaf_into_tree(data, tree) do
+  def add_leaf_to_tree(data, tree) do
     case is_balanced_tree(tree) do
       true -> append_leaf_to_balanced_tree(data, tree)
       false -> append_leaf_to_unbalanced_tree(data, tree)

--- a/lib/merkle_tree_elixir.ex
+++ b/lib/merkle_tree_elixir.ex
@@ -81,8 +81,6 @@ defmodule MerkleTreeElixir do
   end
 
   def audit_trail(index, {_, hash, nil, nil}, list) do
-    IO.puts("final index -> #{index}")
-    IO.inspect(list)
     case rem(trunc(index), 2) do
       0 -> list ++ [{hash, :left}]
       1 -> list ++ [{hash, :right}]
@@ -149,12 +147,12 @@ defmodule MerkleTreeElixir do
   def is_balanced_tree(tree = %MerkleTreeElixir{}), do: is_balanced_tree(tree.right_child)
 
 
-  def part_of_left_subtree?(depth, index) do
+  defp part_of_left_subtree?(depth, index) do
     index < (:math.pow(2, depth) / 2)
   end
 
-  def leaf_index_in_subtree(1,index_in_current_tree), do: index_in_current_tree
-  def leaf_index_in_subtree(depth_of_current_tree, index_in_current_tree) do
+  defp leaf_index_in_subtree(1,index_in_current_tree), do: index_in_current_tree
+  defp leaf_index_in_subtree(depth_of_current_tree, index_in_current_tree) do
     case part_of_left_subtree?(depth_of_current_tree, index_in_current_tree) do
       true -> index_in_current_tree
       false -> index_in_current_tree - :math.pow(2, depth_of_current_tree - 1)
@@ -162,7 +160,7 @@ defmodule MerkleTreeElixir do
   end
 
 
-  def direction_of_new_leaf(number_of_current_leafs) do
+  defp direction_of_new_leaf(number_of_current_leafs) do
     case rem(number_of_current_leafs, 2) do
       0 -> :left
       1 -> :right

--- a/lib/merkle_tree_elixir.ex
+++ b/lib/merkle_tree_elixir.ex
@@ -5,16 +5,20 @@ defmodule MerkleTreeElixir do
 
   def add_leaf_to_tree(data, nil), do: {0, hash_data(data), nil, nil}
 
-  def add_leaf_to_tree(data, tree) do
-    case is_balanced_tree(tree) do
-      true -> append_leaf_to_balanced_tree(data, tree)
-      false -> append_leaf_to_unbalanced_tree(data, tree)
-    end
-  end
+  # def add_leaf_to_tree(data, tree) do
+  #   case is_balanced_tree(tree) do
+  #     true -> append_leaf_to_balanced_tree(data, tree)
+  #     false -> append_leaf_to_unbalanced_tree(data, tree)
+  #   end
+  # end
 
   def is_balanced_tree({_, _, nil, nil}), do: true
   def is_balanced_tree({_, _, left, nil}), do: false
   def is_balanced_tree({_, _, left, right}), do: is_balanced_tree(right)
+  def is_balanced_tree({_, _, left, right}), do: is_balanced_tree(right)
+  def is_balanced_tree(tree = %MerkleTreeElixir{depth: 0, root_hash: nil, left_child: nil, right_child: nil, leafs: [nil]}), do: true
+  def is_balanced_tree(tree = %MerkleTreeElixir{}), do: is_balanced_tree(tree.right_child)
+
 
   def append_leaf_to_unbalanced_tree(new_data, {depth, data, left, nil}) do
     {1, hash_data(data, new_data), left, {0, hash_data(new_data), nil, nil}}

--- a/lib/merkle_tree_elixir.ex
+++ b/lib/merkle_tree_elixir.ex
@@ -13,12 +13,11 @@ defmodule MerkleTreeElixir do
   # end
 
   def is_balanced_tree({_, _, nil, nil}), do: true
-  def is_balanced_tree({_, _, left, nil}), do: false
-  def is_balanced_tree({_, _, left, right}), do: is_balanced_tree(right)
-  def is_balanced_tree({_, _, left, right}), do: is_balanced_tree(right)
+  def is_balanced_tree({_, _, _, nil}), do: false
+  def is_balanced_tree({_, _, _, right}), do: is_balanced_tree(right)
 
   def is_balanced_tree(
-        tree = %MerkleTreeElixir{
+        %MerkleTreeElixir{
           depth: 0,
           root_hash: nil,
           left_child: nil,
@@ -30,13 +29,13 @@ defmodule MerkleTreeElixir do
 
   def is_balanced_tree(tree = %MerkleTreeElixir{}), do: is_balanced_tree(tree.right_child)
 
-  def append_leaf_to_unbalanced_tree(new_data, {depth, data, left, nil}) do
+  def append_leaf_to_unbalanced_tree(new_data, {_, data, left, nil}) do
     {1, hash_data(data, new_data), left, {0, hash_data(new_data), nil, nil}}
   end
 
   def append_leaf_to_unbalanced_tree(
         new_data,
-        {depth, _, {d, data, left_left, right_right}, right}
+        {_, _, {d, data, left_left, right_right}, right}
       ) do
     foo = append_leaf_to_unbalanced_tree(new_data, right)
     {depth, value, _, _} = foo

--- a/lib/merkle_tree_elixir.ex
+++ b/lib/merkle_tree_elixir.ex
@@ -56,15 +56,26 @@ end
   end
 
   def append_leaf_to_unbalanced_tree(new_data, tree = %MerkleTreeElixir{}) do
-    %MerkleTreeElixir{
-      depth: tree.depth + 1,
-      root_hash: hash_data(tree.root_hash, new_data),
-      left_child: tree.left_child,
-      right_child: append_leaf_to_unbalanced_tree(new_data, tree.right_child),
-      leafs: tree.leafs ++ [{hash_data(new_data), :right}]
-    }
+    case rem(length(tree.leafs), 2) do
+      1 -> %MerkleTreeElixir{
+        depth: tree.depth,
+        root_hash: hash_data(tree.root_hash, new_data),
+        left_child: tree.left_child,
+        right_child: append_leaf_to_unbalanced_tree(new_data, tree.right_child),
+        leafs: tree.leafs ++ [{hash_data(new_data), :right}]
+      }
+      2 -> %MerkleTreeElixir{
+        depth: tree.depth,
+        root_hash: hash_data(tree.root_hash, new_data),
+        left_child: tree.left_child,
+        right_child: append_leaf_to_unbalanced_tree(new_data, tree.right_child),
+        leafs: tree.leafs ++ [{hash_data(new_data), :left}]
+      }
+    end
   end
 
+
+  
   def append_leaf_to_balanced_tree(data, tree = %MerkleTreeElixir{}) do
     %MerkleTreeElixir{
       depth: tree.depth + 1,

--- a/lib/merkle_tree_elixir.ex
+++ b/lib/merkle_tree_elixir.ex
@@ -55,10 +55,6 @@ defmodule MerkleTreeElixir do
     end
   end
 
-  def find_index_of_leaf(_, _, []), do: false
-  def find_index_of_leaf(index, hash, [{hash, _} | _]), do: index
-  def find_index_of_leaf(index, hash, [H | T]), do: find_index_of_leaf(index + 1, hash, T)
-
   def is_balanced_tree({_, _, nil, nil}), do: true
   def is_balanced_tree({_, _, _, nil}), do: false
   def is_balanced_tree({_, _, _, right}), do: is_balanced_tree(right)

--- a/lib/merkle_tree_elixir.ex
+++ b/lib/merkle_tree_elixir.ex
@@ -4,7 +4,6 @@ defmodule MerkleTreeElixir do
   def new_tree(), do: %MerkleTreeElixir{}
 
   def add_leaf_to_tree(data, %MerkleTreeElixir{ left_child: nil}) do
-      
       hash = hash_data(data)
 
       %MerkleTreeElixir{
@@ -16,7 +15,6 @@ defmodule MerkleTreeElixir do
       }
   end
   def add_leaf_to_tree(data, tree = %MerkleTreeElixir{ right_child: nil}) do
-      
     hash = hash_data(data)
 
     %MerkleTreeElixir{
@@ -35,12 +33,14 @@ end
     end
   end
 
+
   def is_balanced_tree(nil), do: false
   def is_balanced_tree({_, _, nil, nil}), do: true
   def is_balanced_tree({_, _, _, nil}), do: false
   def is_balanced_tree({_, _, _, right}), do: is_balanced_tree(right)
   def is_balanced_tree(%MerkleTreeElixir{depth: 0}), do: true
   def is_balanced_tree(tree = %MerkleTreeElixir{}), do: is_balanced_tree(tree.right_child)
+
 
   def append_leaf_to_unbalanced_tree(new_data, {_, data, left, nil}) do
     {1, hash_data(data, new_data), left, {0, hash_data(new_data), nil, nil}}
@@ -75,10 +75,7 @@ end
     }
   end
 
-  def bubble_down(0, data) do
-    {0, hash_data(data), nil, nil}
-  end
-
+  def bubble_down(0, data), do: {0, hash_data(data), nil, nil}
   def bubble_down(depth, data) do
     {depth, hash_data(data), bubble_down(depth - 1, data), nil}
   end
@@ -139,35 +136,33 @@ end
     end
   end
 
+
   def verify_audit_trail(_, []), do: false
-
-  def verify_audit_trail(root_hash, list),
-    do: verify_audit_trail(root_hash, "", Enum.reverse(list))
-
+  def verify_audit_trail(root_hash, list), do: verify_audit_trail(root_hash, "", Enum.reverse(list))
   def verify_audit_trail(root_hash, root_hash, []), do: true
   def verify_audit_trail(_, _, []), do: false
 
   def verify_audit_trail(root_hash, audit_hash, [{nil, :right} | tail]) do
     verify_audit_trail(root_hash, hash_data(audit_hash, ""), tail)
   end
-
   def verify_audit_trail(root_hash, audit_hash, [{new_hash, :right} | tail]) do
     verify_audit_trail(root_hash, hash_data(audit_hash, new_hash), tail)
   end
-
   def verify_audit_trail(root_hash, audit_hash, [{new_hash, :left} | tail]) do
     verify_audit_trail(root_hash, hash_data(new_hash, audit_hash), tail)
   end
+
+
+  def part_of_left_subtree?(depth, index) do
+    index < :math.pow(2, depth) / 2
+  end
+
 
   def hash_data(data) do
     to_string(data)
     # :crypto.hash_data(:sha256, to_string(data)) 
     # |> Base.encode16 
     # |> String.downcase
-  end
-
-  def part_of_left_subtree?(depth, index) do
-    index < :math.pow(2, depth) / 2
   end
 
   def hash_data(one, two) do

--- a/lib/merkle_tree_elixir.ex
+++ b/lib/merkle_tree_elixir.ex
@@ -13,7 +13,7 @@ defmodule MerkleTreeElixir do
   end
 
   def audit_trail(hash_to_be_audited, tree = %MerkleTreeElixir{}) do
-    index = Enum.find_index(tree.leafs, fn({x, _}) -> x == hash_to_be_audited end)
+    index = Enum.find_index(tree.leafs, fn {x, _} -> x == hash_to_be_audited end)
 
     case index do
       nil -> []
@@ -36,7 +36,10 @@ defmodule MerkleTreeElixir do
   end
 
   def audit_trail(_, {_, _, nil, nil}, list), do: list
-  def audit_trail(index, {depth, hash, left_child, nil}, list), do: audit_trail(index, left_child, list ++ [{nil, :right}])
+
+  def audit_trail(index, {depth, hash, left_child, nil}, list),
+    do: audit_trail(index, left_child, list ++ [{nil, :right}])
+
   def audit_trail(
         index,
         {depth, hash, {left_depth, left_hash, left_left, left_right},
@@ -50,8 +53,13 @@ defmodule MerkleTreeElixir do
           {right_depth, right_hash, right_left, right_right},
           list ++ [{right_hash, :right}]
         )
+
       false ->
-        audit_trail(index, {left_depth, left_hash, left_left, left_right}, list ++ [{left_hash, :left}])
+        audit_trail(
+          index,
+          {left_depth, left_hash, left_left, left_right},
+          list ++ [{left_hash, :left}]
+        )
     end
   end
 

--- a/lib/merkle_tree_elixir.ex
+++ b/lib/merkle_tree_elixir.ex
@@ -16,9 +16,19 @@ defmodule MerkleTreeElixir do
   def is_balanced_tree({_, _, left, nil}), do: false
   def is_balanced_tree({_, _, left, right}), do: is_balanced_tree(right)
   def is_balanced_tree({_, _, left, right}), do: is_balanced_tree(right)
-  def is_balanced_tree(tree = %MerkleTreeElixir{depth: 0, root_hash: nil, left_child: nil, right_child: nil, leafs: [nil]}), do: true
-  def is_balanced_tree(tree = %MerkleTreeElixir{}), do: is_balanced_tree(tree.right_child)
 
+  def is_balanced_tree(
+        tree = %MerkleTreeElixir{
+          depth: 0,
+          root_hash: nil,
+          left_child: nil,
+          right_child: nil,
+          leafs: [nil]
+        }
+      ),
+      do: true
+
+  def is_balanced_tree(tree = %MerkleTreeElixir{}), do: is_balanced_tree(tree.right_child)
 
   def append_leaf_to_unbalanced_tree(new_data, {depth, data, left, nil}) do
     {1, hash_data(data, new_data), left, {0, hash_data(new_data), nil, nil}}
@@ -31,6 +41,16 @@ defmodule MerkleTreeElixir do
     foo = append_leaf_to_unbalanced_tree(new_data, right)
     {depth, value, _, _} = foo
     {depth + 1, hash_data(data, value), {d, data, left_left, right_right}, foo}
+  end
+
+  def append_leaf_to_unbalanced_tree(new_data, tree = %MerkleTreeElixir{}) do
+    %MerkleTreeElixir{
+      depth: tree.depth + 1,
+      root_hash: hash_data(tree.root_hash, new_data),
+      left_child: tree.left_child,
+      right_child: append_leaf_to_unbalanced_tree(new_data, tree.right_child),
+      leafs: tree.leafs ++ [{hash_data(new_data), :right}]
+    }
   end
 
   def append_leaf_to_balanced_tree(data, tree = %MerkleTreeElixir{}) do

--- a/test/merkle_tree_elixir_test.exs
+++ b/test/merkle_tree_elixir_test.exs
@@ -2,6 +2,11 @@ defmodule MerkleTreeElixirTest do
   use ExUnit.Case
   doctest MerkleTreeElixir
 
+  test "create new tree" do
+    assert(MerkleTreeElixir.new_tree() == %MerkleTreeElixir{depth: 0, root_hash: nil, left_child: nil, right_child: nil, leafs: [nil]})
+  end
+
+
   test "detect a new tree is balanced" do
     assert(MerkleTreeElixir.is_balanced_tree({0, 1, nil, nil}))
   end

--- a/test/merkle_tree_elixir_test.exs
+++ b/test/merkle_tree_elixir_test.exs
@@ -97,7 +97,7 @@ defmodule MerkleTreeElixirTest do
     )
   end
 
-  test "return empty list for audit_trail if hash non-existent in tree" do
+  test "return empty list for audit_trail if hash is not a leaf in the tree" do
     tree = %MerkleTreeElixir{
       depth: 1,
       root_hash: "12",
@@ -118,9 +118,9 @@ defmodule MerkleTreeElixirTest do
       leafs: [{"1", :left}, {"2", :right}, {"3", :left}]
     }
 
-    assert(MerkleTreeElixir.audit_trail("1", tree) == [{"3", :right}, {"2", :right}])
-    assert(MerkleTreeElixir.audit_trail("2", tree) == [{"3", :right}, {"1", :left}])
-    assert(MerkleTreeElixir.audit_trail("3", tree) == [{"12", :left}, {nil, :right}])
+    assert(MerkleTreeElixir.audit_trail("1", tree) == [{"3", :right}, {"2", :right}, {"1", :left}])
+    assert(MerkleTreeElixir.audit_trail("2", tree) == [{"3", :right}, {"1", :left}, {"2", :right}])
+    assert(MerkleTreeElixir.audit_trail("3", tree) == [{"12", :left}, {nil, :right}, {"3", :left}])
   end
 
   test "find audit trail for balanced tree" do
@@ -132,7 +132,27 @@ defmodule MerkleTreeElixirTest do
       leafs: [{"1", :left}, {"2", :right}]
     }
 
-    assert(MerkleTreeElixir.audit_trail("1", tree) == [{"2", :right}])
-    assert(MerkleTreeElixir.audit_trail("2", tree) == [{"1", :left}])
+    assert(MerkleTreeElixir.audit_trail("1", tree) == [{"2", :right}, {"1", :left}])
+    assert(MerkleTreeElixir.audit_trail("2", tree) == [{"1", :left}, {"2", :right}])
+  end
+
+  test " Verify audit trail" do
+    tree = %MerkleTreeElixir{
+      depth: 2,
+      root_hash: "123",
+      left_child: {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
+      right_child: {1, "3", {0, "3", nil, nil}, nil},
+      leafs: [{"1", :left}, {"2", :right}, {"3", :left}]
+    }
+
+    audit_trail = MerkleTreeElixir.audit_trail("1", tree)
+    assert(MerkleTreeElixir.verify_audit_trail(tree.root_hash, audit_trail) == true)
+    audit_trail = MerkleTreeElixir.audit_trail("2", tree)
+    assert(MerkleTreeElixir.verify_audit_trail(tree.root_hash, audit_trail) == true)
+    audit_trail = MerkleTreeElixir.audit_trail("3", tree)
+    IO.inspect(audit_trail)
+    assert(MerkleTreeElixir.verify_audit_trail(tree.root_hash, audit_trail) == true)
+    audit_trail = MerkleTreeElixir.audit_trail("3124", tree)
+    refute(MerkleTreeElixir.verify_audit_trail(tree.root_hash, audit_trail) == true)
   end
 end

--- a/test/merkle_tree_elixir_test.exs
+++ b/test/merkle_tree_elixir_test.exs
@@ -40,15 +40,14 @@ defmodule MerkleTreeElixirTest do
   end
 
   test "add leaf to balanced tree parent" do
-    tree = {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}}
+    tree = %MerkleTreeElixir{depth: 1, root_hash: "12", left_child: {0, "1", nil, nil}, right_child: {0, "2", nil, nil}, leafs: [{"1", :left} , {"2", :right}]}
 
     tree = MerkleTreeElixir.append_leaf_to_balanced_tree("3", tree)
     IO.inspect(tree)
 
     assert(
       tree ==
-        {2, "123", {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
-         {1, "3", {0, "3", nil, nil}, nil}}
+      %MerkleTreeElixir{depth: 2, root_hash: "123", left_child: {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}}, right_child: {1, "3", {0, "3", nil, nil}, nil}, leafs: [{"1", :left}, {"2", :right}, {"3", :left}]}
     )
   end
 end

--- a/test/merkle_tree_elixir_test.exs
+++ b/test/merkle_tree_elixir_test.exs
@@ -14,20 +14,38 @@ defmodule MerkleTreeElixirTest do
     )
   end
 
-  test "detect a new tree is balanced" do
-    assert(MerkleTreeElixir.is_balanced_tree({0, 1, nil, nil}))
+  test "detect a balanced tree" do
+    tree = %MerkleTreeElixir{
+      depth: 1,
+      root_hash: "12",
+      left_child: {0, "1", nil, nil},
+      right_child: {0, "2", nil, nil},
+      leafs: [{"1", :left}, {"2", :right}]
+    }
+
+    assert(MerkleTreeElixir.is_balanced_tree(tree))
+    assert(MerkleTreeElixir.is_balanced_tree(MerkleTreeElixir.new_tree()))
   end
 
-  test "detect a balanced tree" do
-    tree =
-      {2, 1234, {1, 12, {0, 1, nil, nil}, {0, 2, nil, nil}},
-       {1, 34, {0, 3, nil, nil}, {0, 4, nil, nil}}}
-
+  test "detect a unbalanced tree" do
+    tree = %MerkleTreeElixir{
+      depth: 1,
+      root_hash: "12",
+      left_child: {0, "1", nil, nil},
+      right_child: {0, "2", nil, nil},
+      leafs: [{"1", :left}, {"2", :right}]
+    }
     assert(MerkleTreeElixir.is_balanced_tree(tree))
   end
 
   test "detect an unbalanced tree" do
-    tree = {2, 1234, {1, 12, {0, 1, nil, nil}, {0, 2, nil, nil}}, {1, 34, {0, 3, nil, nil}, nil}}
+    tree = %MerkleTreeElixir{
+      depth: 2,
+      root_hash: "123",
+      left_child: {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
+      right_child: {1, "3", {0, "3", nil, nil}, nil},
+      leafs: [{"1", :left}, {"2", :right}, {"3", :left}]
+    }
     refute(MerkleTreeElixir.is_balanced_tree(tree))
   end
 

--- a/test/merkle_tree_elixir_test.exs
+++ b/test/merkle_tree_elixir_test.exs
@@ -22,13 +22,16 @@ defmodule MerkleTreeElixirTest do
       right_child: nil,
       leafs: [nil]
     }
-    assert(MerkleTreeElixir.add_leaf_to_tree("1", tree) == %MerkleTreeElixir{
-      depth: 1,
-      root_hash: "1",
-      left_child: {0, "1", nil, nil},
-      right_child: nil,
-      leafs: [{"1", :left}]
-    })
+
+    assert(
+      MerkleTreeElixir.add_leaf_to_tree("1", tree) == %MerkleTreeElixir{
+        depth: 1,
+        root_hash: "1",
+        left_child: {0, "1", nil, nil},
+        right_child: nil,
+        leafs: [{"1", :left}]
+      }
+    )
   end
 
   test "add data to tree with 1 leaf" do
@@ -39,13 +42,16 @@ defmodule MerkleTreeElixirTest do
       right_child: nil,
       leafs: [{"1", :left}]
     }
-    assert(MerkleTreeElixir.add_leaf_to_tree("2", tree) == %MerkleTreeElixir{
-      depth: 1,
-      root_hash: "12",
-      left_child: {0, "1", nil, nil},
-      right_child: {0, "2", nil, nil},
-      leafs: [{"1", :left}, {"2", :right}]
-    })
+
+    assert(
+      MerkleTreeElixir.add_leaf_to_tree("2", tree) == %MerkleTreeElixir{
+        depth: 1,
+        root_hash: "12",
+        left_child: {0, "1", nil, nil},
+        right_child: {0, "2", nil, nil},
+        leafs: [{"1", :left}, {"2", :right}]
+      }
+    )
   end
 
   test "detect a balanced tree" do
@@ -120,23 +126,25 @@ defmodule MerkleTreeElixirTest do
   end
 
   test "add 4 leafs consecutively" do
-    tree = MerkleTreeElixir.new_tree
+    tree = MerkleTreeElixir.new_tree()
     tree = MerkleTreeElixir.add_leaf_to_tree("1", tree)
     tree = MerkleTreeElixir.add_leaf_to_tree("2", tree)
     tree = MerkleTreeElixir.add_leaf_to_tree("3", tree)
     tree = MerkleTreeElixir.add_leaf_to_tree("4", tree)
 
-    assert(tree == %MerkleTreeElixir{
-      depth: 2,
-      leafs: [{"1", :left}, {"2", :right}, {"3", :left}, {"4", :right}],
-      left_child: {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
-      right_child: {1, "34", {0, "3", nil, nil}, {0, "4", nil, nil}},
-      root_hash: "1234"
-    })
+    assert(
+      tree == %MerkleTreeElixir{
+        depth: 2,
+        leafs: [{"1", :left}, {"2", :right}, {"3", :left}, {"4", :right}],
+        left_child: {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
+        right_child: {1, "34", {0, "3", nil, nil}, {0, "4", nil, nil}},
+        root_hash: "1234"
+      }
+    )
   end
 
   test "add 8 leafs consecutively" do
-    tree = MerkleTreeElixir.new_tree
+    tree = MerkleTreeElixir.new_tree()
     tree = MerkleTreeElixir.add_leaf_to_tree("1", tree)
     tree = MerkleTreeElixir.add_leaf_to_tree("2", tree)
     tree = MerkleTreeElixir.add_leaf_to_tree("3", tree)
@@ -146,16 +154,28 @@ defmodule MerkleTreeElixirTest do
     tree = MerkleTreeElixir.add_leaf_to_tree("7", tree)
     tree = MerkleTreeElixir.add_leaf_to_tree("8", tree)
 
-    assert(tree == %MerkleTreeElixir{
-      depth: 3,
-      leafs: [{"1", :left}, {"2", :right}, {"3", :left}, {"4", :right},
-      {"5", :left}, {"6", :right}, {"7", :left}, {"8", :right}],
-      left_child: {2, "1234", {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
-      {1, "34", {0, "3", nil, nil}, {0, "4", nil, nil}}},
-      right_child: {2, "5678", {1, "56", {0, "5", nil, nil}, {0, "6", nil, nil}},
-      {1, "78", {0, "7", nil, nil}, {0, "8", nil, nil}}},
-      root_hash: "12345678"
-    })
+    assert(
+      tree == %MerkleTreeElixir{
+        depth: 3,
+        leafs: [
+          {"1", :left},
+          {"2", :right},
+          {"3", :left},
+          {"4", :right},
+          {"5", :left},
+          {"6", :right},
+          {"7", :left},
+          {"8", :right}
+        ],
+        left_child:
+          {2, "1234", {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
+           {1, "34", {0, "3", nil, nil}, {0, "4", nil, nil}}},
+        right_child:
+        {2, "5678", {1, "56", {0, "5", nil, nil}, {0, "6", nil, nil}},
+        {1, "78", {0, "7", nil, nil}, {0, "8", nil, nil}}},
+        root_hash: "12345678"
+      }
+    )
   end
 
   test "return empty list for audit_trail if hash is not a leaf in the tree" do
@@ -226,4 +246,39 @@ defmodule MerkleTreeElixirTest do
     audit_trail = MerkleTreeElixir.audit_trail("3124", tree)
     refute(MerkleTreeElixir.verify_audit_trail(tree.root_hash, audit_trail) == true)
   end
+
+  test "Audit trail on larger trees leaf > 7" do
+    
+    tree = %MerkleTreeElixir{
+      depth: 3,
+      leafs: [
+        {"1", :left},
+        {"2", :right},
+        {"3", :left},
+        {"4", :right},
+        {"5", :left},
+        {"6", :right},
+        {"7", :left},
+        {"8", :right}
+      ],
+      left_child:
+        {2, "1234", {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
+         {1, "34", {0, "3", nil, nil}, {0, "4", nil, nil}}},
+      right_child:
+      {2, "5678", {1, "56", {0, "5", nil, nil}, {0, "6", nil, nil}},
+      {1, "78", {0, "7", nil, nil}, {0, "8", nil, nil}}},
+      root_hash: "12345678"
+    }
+
+    assert(MerkleTreeElixir.verify_audit_trail(tree.root_hash, MerkleTreeElixir.audit_trail("2", tree)) == true)
+    assert(MerkleTreeElixir.verify_audit_trail(tree.root_hash, MerkleTreeElixir.audit_trail("5", tree)) == true)
+    assert(MerkleTreeElixir.verify_audit_trail(tree.root_hash, MerkleTreeElixir.audit_trail("7", tree)) == true)
+    assert(MerkleTreeElixir.verify_audit_trail(tree.root_hash, MerkleTreeElixir.audit_trail("8", tree)) == true)
+    refute(MerkleTreeElixir.verify_audit_trail(tree.root_hash, MerkleTreeElixir.audit_trail("9", tree)) == true)
+    refute(MerkleTreeElixir.verify_audit_trail(tree.root_hash, MerkleTreeElixir.audit_trail("0", tree)) == true)
+
+
+  end
+
+
 end

--- a/test/merkle_tree_elixir_test.exs
+++ b/test/merkle_tree_elixir_test.exs
@@ -3,9 +3,16 @@ defmodule MerkleTreeElixirTest do
   doctest MerkleTreeElixir
 
   test "create new tree" do
-    assert(MerkleTreeElixir.new_tree() == %MerkleTreeElixir{depth: 0, root_hash: nil, left_child: nil, right_child: nil, leafs: [nil]})
+    assert(
+      MerkleTreeElixir.new_tree() == %MerkleTreeElixir{
+        depth: 0,
+        root_hash: nil,
+        left_child: nil,
+        right_child: nil,
+        leafs: [nil]
+      }
+    )
   end
-
 
   test "detect a new tree is balanced" do
     assert(MerkleTreeElixir.is_balanced_tree({0, 1, nil, nil}))
@@ -40,14 +47,26 @@ defmodule MerkleTreeElixirTest do
   end
 
   test "add leaf to balanced tree parent" do
-    tree = %MerkleTreeElixir{depth: 1, root_hash: "12", left_child: {0, "1", nil, nil}, right_child: {0, "2", nil, nil}, leafs: [{"1", :left} , {"2", :right}]}
+    tree = %MerkleTreeElixir{
+      depth: 1,
+      root_hash: "12",
+      left_child: {0, "1", nil, nil},
+      right_child: {0, "2", nil, nil},
+      leafs: [{"1", :left}, {"2", :right}]
+    }
 
     tree = MerkleTreeElixir.append_leaf_to_balanced_tree("3", tree)
     IO.inspect(tree)
 
     assert(
       tree ==
-      %MerkleTreeElixir{depth: 2, root_hash: "123", left_child: {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}}, right_child: {1, "3", {0, "3", nil, nil}, nil}, leafs: [{"1", :left}, {"2", :right}, {"3", :left}]}
+        %MerkleTreeElixir{
+          depth: 2,
+          root_hash: "123",
+          left_child: {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
+          right_child: {1, "3", {0, "3", nil, nil}, nil},
+          leafs: [{"1", :left}, {"2", :right}, {"3", :left}]
+        }
     )
   end
 end

--- a/test/merkle_tree_elixir_test.exs
+++ b/test/merkle_tree_elixir_test.exs
@@ -105,6 +105,7 @@ defmodule MerkleTreeElixirTest do
       right_child: {0, "2", nil, nil},
       leafs: [{"1", :left}, {"2", :right}]
     }
+
     assert(MerkleTreeElixir.audit_trail("45", tree) == [])
   end
 
@@ -116,10 +117,10 @@ defmodule MerkleTreeElixirTest do
       right_child: {1, "3", {0, "3", nil, nil}, nil},
       leafs: [{"1", :left}, {"2", :right}, {"3", :left}]
     }
+
     assert(MerkleTreeElixir.audit_trail("1", tree) == [{"3", :right}, {"2", :right}])
     assert(MerkleTreeElixir.audit_trail("2", tree) == [{"3", :right}, {"1", :left}])
     assert(MerkleTreeElixir.audit_trail("3", tree) == [{"12", :left}, {nil, :right}])
-
   end
 
   test "find audit trail for balanced tree" do
@@ -130,6 +131,7 @@ defmodule MerkleTreeElixirTest do
       right_child: {0, "2", nil, nil},
       leafs: [{"1", :left}, {"2", :right}]
     }
+
     assert(MerkleTreeElixir.audit_trail("1", tree) == [{"2", :right}])
     assert(MerkleTreeElixir.audit_trail("2", tree) == [{"1", :left}])
   end

--- a/test/merkle_tree_elixir_test.exs
+++ b/test/merkle_tree_elixir_test.exs
@@ -61,18 +61,6 @@ defmodule MerkleTreeElixirTest do
     assert(MerkleTreeElixir.is_balanced_tree(MerkleTreeElixir.new_tree()))
   end
 
-  test "detect a unbalanced tree" do
-    tree = %MerkleTreeElixir{
-      depth: 1,
-      root_hash: "12",
-      left_child: {0, "1", nil, nil},
-      right_child: {0, "2", nil, nil},
-      leafs: [{"1", :left}, {"2", :right}]
-    }
-
-    assert(MerkleTreeElixir.is_balanced_tree(tree))
-  end
-
   test "detect an unbalanced tree" do
     tree = %MerkleTreeElixir{
       depth: 2,
@@ -129,6 +117,41 @@ defmodule MerkleTreeElixirTest do
           leafs: [{"1", :left}, {"2", :right}, {"3", :left}]
         }
     )
+  end
+
+  test "add many leafs consecutively" do
+    tree = MerkleTreeElixir.new_tree
+    tree = MerkleTreeElixir.add_leaf_to_tree("1", tree)
+    tree = MerkleTreeElixir.add_leaf_to_tree("2", tree)
+    tree = MerkleTreeElixir.add_leaf_to_tree("3", tree)
+    tree = MerkleTreeElixir.add_leaf_to_tree("4", tree)
+
+    assert(tree == %MerkleTreeElixir{
+      depth: 2,
+      leafs: [{"1", :left}, {"2", :right}, {"3", :left}, {"4", :right}],
+      left_child: {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
+      right_child: {1, "34", {0, "3", nil, nil}, {0, "4", nil, nil}},
+      root_hash: "1234"
+    })
+
+    tree = MerkleTreeElixir.add_leaf_to_tree("5", tree)
+    tree = MerkleTreeElixir.add_leaf_to_tree("6", tree)
+    tree = MerkleTreeElixir.add_leaf_to_tree("7", tree)
+    tree = MerkleTreeElixir.add_leaf_to_tree("8", tree)
+
+    assert(true)
+
+    assert(tree == %MerkleTreeElixir{
+      depth: 3,
+      leafs: [{"1", :left}, {"2", :right}, {"3", :left}, {"4", :right},
+      {"5", :left}, {"6", :right}, {"7", :left}, {"8", :right}],
+      left_child: {2, "1234", {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
+      {1, "34", {0, "3", nil, nil}, {0, "4", nil, nil}}},
+      right_child: {2, "5678", {1, "56", {0, "5", nil, nil}, {0, "6", nil, nil}},
+      {1, "78", {0, "7", nil, nil}, {0, "8", nil, nil}}},
+      root_hash: "12345678"
+    })
+
   end
 
   test "return empty list for audit_trail if hash is not a leaf in the tree" do

--- a/test/merkle_tree_elixir_test.exs
+++ b/test/merkle_tree_elixir_test.exs
@@ -35,6 +35,7 @@ defmodule MerkleTreeElixirTest do
       right_child: {0, "2", nil, nil},
       leafs: [{"1", :left}, {"2", :right}]
     }
+
     assert(MerkleTreeElixir.is_balanced_tree(tree))
   end
 
@@ -46,21 +47,31 @@ defmodule MerkleTreeElixirTest do
       right_child: {1, "3", {0, "3", nil, nil}, nil},
       leafs: [{"1", :left}, {"2", :right}, {"3", :left}]
     }
+
     refute(MerkleTreeElixir.is_balanced_tree(tree))
   end
 
   test "add leaf to unbalanced tree" do
-    tree =
-      {2, "123", {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
-       {1, "3", {0, "3", nil, nil}, nil}}
+    tree = %MerkleTreeElixir{
+      depth: 2,
+      root_hash: "123",
+      left_child: {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
+      right_child: {1, "3", {0, "3", nil, nil}, nil},
+      leafs: [{"1", :left}, {"2", :right}, {"3", :left}]
+    }
 
     tree = MerkleTreeElixir.append_leaf_to_unbalanced_tree("4", tree)
     IO.inspect(tree)
 
     assert(
       tree ==
-        {2, "1234", {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
-         {1, "34", {0, "3", nil, nil}, {0, "4", nil, nil}}}
+      %MerkleTreeElixir{
+        depth: 3,
+        root_hash: "1234",
+        left_child: {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
+        right_child: {1, "34", {0, "3", nil, nil}, {0, "4", nil, nil}},
+        leafs: [{"1", :left}, {"2", :right}, {"3", :left}, {"4", :right}]
+      }
     )
   end
 

--- a/test/merkle_tree_elixir_test.exs
+++ b/test/merkle_tree_elixir_test.exs
@@ -87,7 +87,7 @@ defmodule MerkleTreeElixirTest do
     assert(
       tree ==
         %MerkleTreeElixir{
-          depth: 3,
+          depth: 2,
           root_hash: "1234",
           left_child: {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
           right_child: {1, "34", {0, "3", nil, nil}, {0, "4", nil, nil}},
@@ -119,7 +119,7 @@ defmodule MerkleTreeElixirTest do
     )
   end
 
-  test "add many leafs consecutively" do
+  test "add 4 leafs consecutively" do
     tree = MerkleTreeElixir.new_tree
     tree = MerkleTreeElixir.add_leaf_to_tree("1", tree)
     tree = MerkleTreeElixir.add_leaf_to_tree("2", tree)
@@ -133,13 +133,18 @@ defmodule MerkleTreeElixirTest do
       right_child: {1, "34", {0, "3", nil, nil}, {0, "4", nil, nil}},
       root_hash: "1234"
     })
+  end
 
+  test "add 8 leafs consecutively" do
+    tree = MerkleTreeElixir.new_tree
+    tree = MerkleTreeElixir.add_leaf_to_tree("1", tree)
+    tree = MerkleTreeElixir.add_leaf_to_tree("2", tree)
+    tree = MerkleTreeElixir.add_leaf_to_tree("3", tree)
+    tree = MerkleTreeElixir.add_leaf_to_tree("4", tree)
     tree = MerkleTreeElixir.add_leaf_to_tree("5", tree)
     tree = MerkleTreeElixir.add_leaf_to_tree("6", tree)
     tree = MerkleTreeElixir.add_leaf_to_tree("7", tree)
     tree = MerkleTreeElixir.add_leaf_to_tree("8", tree)
-
-    assert(true)
 
     assert(tree == %MerkleTreeElixir{
       depth: 3,
@@ -151,7 +156,6 @@ defmodule MerkleTreeElixirTest do
       {1, "78", {0, "7", nil, nil}, {0, "8", nil, nil}}},
       root_hash: "12345678"
     })
-
   end
 
   test "return empty list for audit_trail if hash is not a leaf in the tree" do

--- a/test/merkle_tree_elixir_test.exs
+++ b/test/merkle_tree_elixir_test.exs
@@ -14,19 +14,6 @@ defmodule MerkleTreeElixirTest do
     )
   end
 
-  test "find index of leaf with a hash" do
-    tree = %MerkleTreeElixir{
-      depth: 2,
-      root_hash: "123",
-      left_child: {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
-      right_child: {1, "3", {0, "3", nil, nil}, nil},
-      leafs: [{"1", :left}, {"2", :right}, {"3", :left}]
-    }
-
-    assert(MerkleTreeElixir.)
-
-  end
-
   test "detect a balanced tree" do
     tree = %MerkleTreeElixir{
       depth: 1,
@@ -77,13 +64,13 @@ defmodule MerkleTreeElixirTest do
 
     assert(
       tree ==
-      %MerkleTreeElixir{
-        depth: 3,
-        root_hash: "1234",
-        left_child: {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
-        right_child: {1, "34", {0, "3", nil, nil}, {0, "4", nil, nil}},
-        leafs: [{"1", :left}, {"2", :right}, {"3", :left}, {"4", :right}]
-      }
+        %MerkleTreeElixir{
+          depth: 3,
+          root_hash: "1234",
+          left_child: {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
+          right_child: {1, "34", {0, "3", nil, nil}, {0, "4", nil, nil}},
+          leafs: [{"1", :left}, {"2", :right}, {"3", :left}, {"4", :right}]
+        }
     )
   end
 
@@ -110,21 +97,40 @@ defmodule MerkleTreeElixirTest do
     )
   end
 
-  test "find audit trail for balanced tree" do
-    tree =
-        %MerkleTreeElixir{
-          depth: 2,
-          root_hash: "123",
-          left_child: {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
-          right_child: {1, "3", {0, "3", nil, nil}, nil},
-          leafs: [{"1", :left}, {"2", :right}, {"3", :left}]
-        }
-      hash = MerkleTreeElixir.hash_data("3")
-      audit_trail = MerkleTreeElixir.audit_trail(hash)
-
-    assert(audit_trail == [{nil}, {"12", :left}])
+  test "return empty list for audit_trail if hash non-existent in tree" do
+    tree = %MerkleTreeElixir{
+      depth: 1,
+      root_hash: "12",
+      left_child: {0, "1", nil, nil},
+      right_child: {0, "2", nil, nil},
+      leafs: [{"1", :left}, {"2", :right}]
+    }
+    assert(MerkleTreeElixir.audit_trail("45", tree) == [])
   end
 
+  test "find audit trail for unbalanced tree" do
+    tree = %MerkleTreeElixir{
+      depth: 2,
+      root_hash: "123",
+      left_child: {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
+      right_child: {1, "3", {0, "3", nil, nil}, nil},
+      leafs: [{"1", :left}, {"2", :right}, {"3", :left}]
+    }
+    assert(MerkleTreeElixir.audit_trail("1", tree) == [{"3", :right}, {"2", :right}])
+    assert(MerkleTreeElixir.audit_trail("2", tree) == [{"3", :right}, {"1", :left}])
+    assert(MerkleTreeElixir.audit_trail("3", tree) == [{"12", :left}, {nil, :right}])
 
+  end
 
+  test "find audit trail for balanced tree" do
+    tree = %MerkleTreeElixir{
+      depth: 1,
+      root_hash: "12",
+      left_child: {0, "1", nil, nil},
+      right_child: {0, "2", nil, nil},
+      leafs: [{"1", :left}, {"2", :right}]
+    }
+    assert(MerkleTreeElixir.audit_trail("1", tree) == [{"2", :right}])
+    assert(MerkleTreeElixir.audit_trail("2", tree) == [{"1", :left}])
+  end
 end

--- a/test/merkle_tree_elixir_test.exs
+++ b/test/merkle_tree_elixir_test.exs
@@ -14,6 +14,19 @@ defmodule MerkleTreeElixirTest do
     )
   end
 
+  test "find index of leaf with a hash" do
+    tree = %MerkleTreeElixir{
+      depth: 2,
+      root_hash: "123",
+      left_child: {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
+      right_child: {1, "3", {0, "3", nil, nil}, nil},
+      leafs: [{"1", :left}, {"2", :right}, {"3", :left}]
+    }
+
+    assert(MerkleTreeElixir.)
+
+  end
+
   test "detect a balanced tree" do
     tree = %MerkleTreeElixir{
       depth: 1,
@@ -96,4 +109,22 @@ defmodule MerkleTreeElixirTest do
         }
     )
   end
+
+  test "find audit trail for balanced tree" do
+    tree =
+        %MerkleTreeElixir{
+          depth: 2,
+          root_hash: "123",
+          left_child: {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
+          right_child: {1, "3", {0, "3", nil, nil}, nil},
+          leafs: [{"1", :left}, {"2", :right}, {"3", :left}]
+        }
+      hash = MerkleTreeElixir.hash_data("3")
+      audit_trail = MerkleTreeElixir.audit_trail(hash)
+
+    assert(audit_trail == [{nil}, {"12", :left}])
+  end
+
+
+
 end

--- a/test/merkle_tree_elixir_test.exs
+++ b/test/merkle_tree_elixir_test.exs
@@ -198,18 +198,14 @@ defmodule MerkleTreeElixirTest do
       right_child: {1, "3", {0, "3", nil, nil}, nil},
       leafs: [{"1", :left}, {"2", :right}, {"3", :left}]
     }
+    audit_trail = MerkleTreeElixir.audit_trail("1", tree)
+    assert(audit_trail == [{"3", :right}, {"2", :right}, {"1", :left}])
 
-    assert(
-      MerkleTreeElixir.audit_trail("1", tree) == [{"3", :right}, {"2", :right}, {"1", :left}]
-    )
+    audit_trail = MerkleTreeElixir.audit_trail("2", tree)
+    assert(audit_trail == [{"3", :right}, {"1", :left}, {"2", :right}])
 
-    assert(
-      MerkleTreeElixir.audit_trail("2", tree) == [{"3", :right}, {"1", :left}, {"2", :right}]
-    )
-
-    assert(
-      MerkleTreeElixir.audit_trail("3", tree) == [{"12", :left}, {nil, :right}, {"3", :left}]
-    )
+    audit_trail = MerkleTreeElixir.audit_trail("3", tree)
+    assert(audit_trail == [{"12", :left}, {nil, :right}, {"3", :left}])
   end
 
   test "find audit trail for balanced tree" do
@@ -273,6 +269,12 @@ defmodule MerkleTreeElixirTest do
     audit_trail = MerkleTreeElixir.audit_trail("1", tree)
     assert(Enum.reverse(audit_trail) == [{"1", :left}, {"2", :right}, {"34", :right}, {"5678", :right}])
 
+    audit_trail = MerkleTreeElixir.audit_trail("2", tree)
+    assert(Enum.reverse(audit_trail) == [{"2", :right}, {"1", :left}, {"34", :right}, {"5678", :right}])
+
+    audit_trail = MerkleTreeElixir.audit_trail("3", tree)
+    assert(Enum.reverse(audit_trail) == [{"3", :left}, {"4", :right}, {"12", :left}, {"5678", :right}])
+
     audit_trail = MerkleTreeElixir.audit_trail("4", tree)
     assert(Enum.reverse(audit_trail) == [{"4", :right}, {"3", :left}, {"12", :left}, {"5678", :right}])
 
@@ -281,6 +283,9 @@ defmodule MerkleTreeElixirTest do
 
     audit_trail = MerkleTreeElixir.audit_trail("6", tree)
     assert(Enum.reverse(audit_trail) == [{"6", :right}, {"5", :left}, {"78", :right}, {"1234", :left}])
+
+    audit_trail = MerkleTreeElixir.audit_trail("7", tree)
+    assert(Enum.reverse(audit_trail) == [{"7", :left}, {"8", :right}, {"56", :left}, {"1234", :left}])
 
     audit_trail = MerkleTreeElixir.audit_trail("8", tree)
     assert(Enum.reverse(audit_trail) == [{"8", :right}, {"7", :left}, {"56", :left}, {"1234", :left}])

--- a/test/merkle_tree_elixir_test.exs
+++ b/test/merkle_tree_elixir_test.exs
@@ -61,7 +61,6 @@ defmodule MerkleTreeElixirTest do
     }
 
     tree = MerkleTreeElixir.append_leaf_to_unbalanced_tree("4", tree)
-    IO.inspect(tree)
 
     assert(
       tree ==
@@ -85,7 +84,6 @@ defmodule MerkleTreeElixirTest do
     }
 
     tree = MerkleTreeElixir.append_leaf_to_balanced_tree("3", tree)
-    IO.inspect(tree)
 
     assert(
       tree ==

--- a/test/merkle_tree_elixir_test.exs
+++ b/test/merkle_tree_elixir_test.exs
@@ -67,7 +67,7 @@ defmodule MerkleTreeElixirTest do
     assert(MerkleTreeElixir.is_balanced_tree(MerkleTreeElixir.new_tree()))
   end
 
-  test "detect an unbalanced tree" do
+  test "detect a unbalanced tree" do
     tree = %MerkleTreeElixir{
       depth: 2,
       root_hash: "123",
@@ -88,7 +88,7 @@ defmodule MerkleTreeElixirTest do
       leafs: [{"1", :left}, {"2", :right}, {"3", :left}]
     }
 
-    tree = MerkleTreeElixir.append_leaf_to_unbalanced_tree("4", tree)
+    tree = MerkleTreeElixir.add_leaf_to_tree("4", tree)
 
     assert(
       tree ==
@@ -102,7 +102,7 @@ defmodule MerkleTreeElixirTest do
     )
   end
 
-  test "add leaf to balanced tree parent" do
+  test "add leaf to balanced tree" do
     tree = %MerkleTreeElixir{
       depth: 1,
       root_hash: "12",
@@ -111,7 +111,7 @@ defmodule MerkleTreeElixirTest do
       leafs: [{"1", :left}, {"2", :right}]
     }
 
-    tree = MerkleTreeElixir.append_leaf_to_balanced_tree("3", tree)
+    tree = MerkleTreeElixir.add_leaf_to_tree("3", tree)
 
     assert(
       tree ==

--- a/test/merkle_tree_elixir_test.exs
+++ b/test/merkle_tree_elixir_test.exs
@@ -6,12 +6,46 @@ defmodule MerkleTreeElixirTest do
     assert(
       MerkleTreeElixir.new_tree() == %MerkleTreeElixir{
         depth: 0,
-        root_hash: nil,
+        root_hash: "",
         left_child: nil,
         right_child: nil,
         leafs: [nil]
       }
     )
+  end
+
+  test "add data to new tree" do
+    tree = %MerkleTreeElixir{
+      depth: 0,
+      root_hash: "",
+      left_child: nil,
+      right_child: nil,
+      leafs: [nil]
+    }
+    assert(MerkleTreeElixir.add_leaf_to_tree("1", tree) == %MerkleTreeElixir{
+      depth: 1,
+      root_hash: "1",
+      left_child: {0, "1", nil, nil},
+      right_child: nil,
+      leafs: [{"1", :left}]
+    })
+  end
+
+  test "add data to tree with 1 leaf" do
+    tree = %MerkleTreeElixir{
+      depth: 1,
+      root_hash: "1",
+      left_child: {0, "1", nil, nil},
+      right_child: nil,
+      leafs: [{"1", :left}]
+    }
+    assert(MerkleTreeElixir.add_leaf_to_tree("2", tree) == %MerkleTreeElixir{
+      depth: 1,
+      root_hash: "12",
+      left_child: {0, "1", nil, nil},
+      right_child: {0, "2", nil, nil},
+      leafs: [{"1", :left}, {"2", :right}]
+    })
   end
 
   test "detect a balanced tree" do
@@ -118,9 +152,17 @@ defmodule MerkleTreeElixirTest do
       leafs: [{"1", :left}, {"2", :right}, {"3", :left}]
     }
 
-    assert(MerkleTreeElixir.audit_trail("1", tree) == [{"3", :right}, {"2", :right}, {"1", :left}])
-    assert(MerkleTreeElixir.audit_trail("2", tree) == [{"3", :right}, {"1", :left}, {"2", :right}])
-    assert(MerkleTreeElixir.audit_trail("3", tree) == [{"12", :left}, {nil, :right}, {"3", :left}])
+    assert(
+      MerkleTreeElixir.audit_trail("1", tree) == [{"3", :right}, {"2", :right}, {"1", :left}]
+    )
+
+    assert(
+      MerkleTreeElixir.audit_trail("2", tree) == [{"3", :right}, {"1", :left}, {"2", :right}]
+    )
+
+    assert(
+      MerkleTreeElixir.audit_trail("3", tree) == [{"12", :left}, {nil, :right}, {"3", :left}]
+    )
   end
 
   test "find audit trail for balanced tree" do
@@ -147,11 +189,13 @@ defmodule MerkleTreeElixirTest do
 
     audit_trail = MerkleTreeElixir.audit_trail("1", tree)
     assert(MerkleTreeElixir.verify_audit_trail(tree.root_hash, audit_trail) == true)
+
     audit_trail = MerkleTreeElixir.audit_trail("2", tree)
     assert(MerkleTreeElixir.verify_audit_trail(tree.root_hash, audit_trail) == true)
+
     audit_trail = MerkleTreeElixir.audit_trail("3", tree)
-    IO.inspect(audit_trail)
     assert(MerkleTreeElixir.verify_audit_trail(tree.root_hash, audit_trail) == true)
+
     audit_trail = MerkleTreeElixir.audit_trail("3124", tree)
     refute(MerkleTreeElixir.verify_audit_trail(tree.root_hash, audit_trail) == true)
   end

--- a/test/merkle_tree_elixir_test.exs
+++ b/test/merkle_tree_elixir_test.exs
@@ -3,7 +3,7 @@ defmodule MerkleTreeElixirTest do
   doctest MerkleTreeElixir
 
   test "detect a new tree is balanced" do
-    assert(MerkleTreeElixir.is_balanced({0, 1, nil, nil}))
+    assert(MerkleTreeElixir.is_balanced_tree({0, 1, nil, nil}))
   end
 
   test "detect a balanced tree" do
@@ -11,20 +11,20 @@ defmodule MerkleTreeElixirTest do
       {2, 1234, {1, 12, {0, 1, nil, nil}, {0, 2, nil, nil}},
        {1, 34, {0, 3, nil, nil}, {0, 4, nil, nil}}}
 
-    assert(MerkleTreeElixir.is_balanced(tree))
+    assert(MerkleTreeElixir.is_balanced_tree(tree))
   end
 
   test "detect an unbalanced tree" do
     tree = {2, 1234, {1, 12, {0, 1, nil, nil}, {0, 2, nil, nil}}, {1, 34, {0, 3, nil, nil}, nil}}
-    refute(MerkleTreeElixir.is_balanced(tree))
+    refute(MerkleTreeElixir.is_balanced_tree(tree))
   end
 
-  test "add rightmost leaf" do
+  test "add leaf to unbalanced tree" do
     tree =
       {2, "123", {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}},
        {1, "3", {0, "3", nil, nil}, nil}}
 
-    tree = MerkleTreeElixir.append_to_rightmost("4", tree)
+    tree = MerkleTreeElixir.append_leaf_to_unbalanced_tree("4", tree)
     IO.inspect(tree)
 
     assert(
@@ -34,10 +34,10 @@ defmodule MerkleTreeElixirTest do
     )
   end
 
-  test "add parent" do
+  test "add leaf to balanced tree parent" do
     tree = {1, "12", {0, "1", nil, nil}, {0, "2", nil, nil}}
 
-    tree = MerkleTreeElixir.add_parent("3", tree)
+    tree = MerkleTreeElixir.append_leaf_to_balanced_tree("3", tree)
     IO.inspect(tree)
 
     assert(


### PR DESCRIPTION
Now possible to find the audit trail for a leaf as well as verifying it.

The Data Structure was rebuild in order to allow finding the audit trail more conveniently by adding a merkle-tree struct. 

Next up:
- Replacing the pseudo hashing function of hash(a,b)="a"<>"b" OR hash(a)="a" to SHA256